### PR TITLE
Add End-to-End Requester Features: Ticket Categorization, Priority, Comments, and Lifecycle Actions

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,35 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_ticket
+
+  def create
+    @comment = @ticket.comments.build(comment_params)
+    @comment.author = current_user
+    enforce_visibility!
+
+    authorize @comment
+
+    if @comment.save
+      redirect_to @ticket, notice: "Comment added successfully."
+    else
+      flash[:alert] = @comment.errors.full_messages.to_sentence
+      redirect_to @ticket, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_ticket
+    @ticket = Ticket.find(params[:ticket_id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body, :visibility)
+  end
+
+  def enforce_visibility!
+    return unless current_user.requester?
+
+    @comment.visibility = "public"
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@ class Comment < ApplicationRecord
   belongs_to :ticket
   belongs_to :author, class_name: "User"
 
-  enum :visibility, { public: 0, internal: 1 }, validate: true
+  enum :visibility, { public: 0, internal: 1 }, prefix: :visibility, validate: true
 
   validates :body, presence: true
   validates :visibility, presence: true

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,11 @@
+class Comment < ApplicationRecord
+  belongs_to :ticket
+  belongs_to :author, class_name: "User"
+
+  enum :visibility, { public: 0, internal: 1 }, validate: true
+
+  validates :body, presence: true
+  validates :visibility, presence: true
+
+  scope :chronological, -> { order(created_at: :asc) }
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -12,18 +12,21 @@ class Ticket < ApplicationRecord
   enum :status, { open: 0, pending: 1, resolved: 2, closed: 3 }, validate: true
   enum :priority, { low: 0, medium: 1, high: 2 }, validate: true
 
-  attribute :priority, :integer, default: -> { Ticket.priorities[:medium] }
-
   validates :subject, presence: true
   validates :description, presence: true
   validates :status, presence: true
-  validates :priority, inclusion: { in: priorities.keys }
+  validates :priority, presence: true
   validates :category, presence: true, inclusion: { in: CATEGORY_OPTIONS }
   validates :requester, presence: true
 
   before_save :set_closed_at
+  after_initialize :set_default_priority, if: :new_record?
 
   private
+
+  def set_default_priority
+    self.priority ||= :medium
+  end
 
   def set_closed_at
     if closed?

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,14 +1,24 @@
 class Ticket < ApplicationRecord
+  CATEGORY_OPTIONS = [
+    "Technical Issue",
+    "Account Access",
+    "Feature Request"
+  ].freeze
+
   belongs_to :requester, class_name: "User"
   belongs_to :assignee, class_name: "User", optional: true
+  has_many :comments, dependent: :destroy
 
   enum :status, { open: 0, pending: 1, resolved: 2, closed: 3 }, validate: true
-  enum :priority, { low: 0, normal: 1, high: 2 }, validate: true
+  enum :priority, { low: 0, medium: 1, high: 2 }, validate: true
+
+  attribute :priority, :integer, default: -> { Ticket.priorities[:medium] }
 
   validates :subject, presence: true
   validates :description, presence: true
   validates :status, presence: true
-  validates :priority, presence: true
+  validates :priority, inclusion: { in: priorities.keys }
+  validates :category, presence: true, inclusion: { in: CATEGORY_OPTIONS }
   validates :requester, presence: true
 
   before_save :set_closed_at

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -3,7 +3,7 @@ class CommentPolicy < ApplicationPolicy
     return false unless record.ticket.open?
 
     if user.requester?
-      record.ticket.requester == user && record.public?
+      record.ticket.requester == user && record.visibility_public?
     elsif user.agent? || user.admin?
       true
     else

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,13 @@
+class CommentPolicy < ApplicationPolicy
+  def create?
+    return false unless record.ticket.open?
+
+    if user.requester?
+      record.ticket.requester == user && record.public?
+    elsif user.agent? || user.admin?
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/policies/ticket_policy.rb
+++ b/app/policies/ticket_policy.rb
@@ -28,8 +28,12 @@ class TicketPolicy < ApplicationPolicy
   end
 
   def destroy?
-    return false if record.closed?
-    user.admin? || (user.requester? && record.requester == user)
+    return false unless record.open?
+    user.requester? && record.requester == user
+  end
+
+  def close?
+    record.open? && record.requester == user
   end
 
   def assign?

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -17,20 +17,19 @@
     <%= form.text_area :description %>
   </div>
 
-    <div>
+  <div>
     <%= form.label :status %>
     <%= form.select :status, Ticket.statuses.keys.map { |s| [s.titleize, s] } %>
-    </div>
-
+  </div>
 
   <div>
     <%= form.label :priority %>
-    <%= form.select :priority, Ticket.priorities.keys %>
+    <%= form.select :priority, Ticket.priorities.keys.map { |p| [p.titleize, p] }, {}, { class: "priority-select" } %>
   </div>
 
   <div>
     <%= form.label :category %>
-    <%= form.text_field :category %>
+    <%= form.select :category, Ticket::CATEGORY_OPTIONS, { prompt: "Select a category" }, { class: "category-select" } %>
   </div>
 
   <div>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -3,9 +3,15 @@
 <div id="tickets">
   <% @tickets.each do |ticket| %>
     <div>
-      <p><%= ticket.subject %></p>
-      <p><%= ticket.description %></p>
+      <h2><%= link_to ticket.subject, ticket %></h2>
+      <p><strong>Status:</strong> <%= ticket.status.titleize %></p>
+      <p><strong>Priority:</strong> <%= ticket.priority.present? ? ticket.priority.titleize : "Not set" %></p>
+      <p><strong>Category:</strong> <%= ticket.category %></p>
+      <p><%= truncate(ticket.description, length: 160) %></p>
       <p><%= link_to "Show this ticket", ticket %></p>
+      <% if policy(ticket).destroy? %>
+        <%= button_to "Delete", ticket_path(ticket), method: :delete, data: { confirm: "Delete this ticket?" } %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -1,14 +1,82 @@
 <h1><%= @ticket.subject %></h1>
 
-<p><strong>Status:</strong> <%= @ticket.status %></p>
-<p><strong>Priority:</strong> <%= @ticket.priority %></p>
-<p><strong>Requester:</strong> <%= @ticket.requester.display_name %></p>
-<p><strong>Assignee:</strong> <%= @ticket.assignee&.display_name || 'Unassigned' %></p>
-<p><strong>Category:</strong> <%= @ticket.category %></p>
-<p><strong>Description:</strong></p>
-<p><%= @ticket.description %></p>
+<dl>
+  <dt>Status</dt>
+  <dd><%= @ticket.status.titleize %></dd>
 
+  <dt>Priority</dt>
+  <dd><%= @ticket.priority.present? ? @ticket.priority.titleize : "Not set" %></dd>
 
+  <dt>Category</dt>
+  <dd><%= @ticket.category %></dd>
 
-<%= link_to 'Edit', edit_ticket_path(@ticket) %>
-<%= link_to 'Back', tickets_path %>
+  <dt>Requester</dt>
+  <dd><%= @ticket.requester.display_name %></dd>
+
+  <dt>Assignee</dt>
+  <dd><%= @ticket.assignee&.display_name || "Unassigned" %></dd>
+
+  <% if @ticket.closed_at.present? %>
+    <dt>Closed At</dt>
+    <dd><%= l(@ticket.closed_at, format: :long) %></dd>
+  <% end %>
+</dl>
+
+<section>
+  <h2>Description</h2>
+  <div><%= simple_format(@ticket.description) %></div>
+</section>
+
+<div class="ticket-actions">
+  <%= link_to "Edit", edit_ticket_path(@ticket) %>
+  <%= link_to "Back", tickets_path %>
+
+  <% if policy(@ticket).close? %>
+    <%= button_to "Close Ticket", close_ticket_path(@ticket), method: :patch, data: { confirm: "Close this ticket?" } %>
+  <% end %>
+
+  <% if policy(@ticket).destroy? %>
+    <%= button_to "Delete Ticket", ticket_path(@ticket), method: :delete, data: { confirm: "Delete this ticket?" } %>
+  <% end %>
+</div>
+
+<section>
+  <h2>Comments</h2>
+  <% if @comments.any? %>
+    <% @comments.each do |comment| %>
+      <article>
+        <header>
+          <strong><%= comment.author.display_name %></strong>
+          <span>(<%= comment.visibility.titleize %>)</span>
+          <time><%= l(comment.created_at, format: :long) %></time>
+        </header>
+        <div><%= simple_format(comment.body) %></div>
+      </article>
+    <% end %>
+  <% else %>
+    <p>No comments yet.</p>
+  <% end %>
+</section>
+
+<% if policy(@comment).create? %>
+  <section>
+    <h3>Add a Comment</h3>
+    <%= form_with(model: [@ticket, @comment]) do |form| %>
+      <div>
+        <%= form.label :body, "Comment" %>
+        <%= form.text_area :body %>
+      </div>
+
+      <% if current_user.agent? || current_user.admin? %>
+        <div>
+          <%= form.label :visibility %>
+          <%= form.select :visibility, Comment.visibilities.keys.map { |v| [v.titleize, v] } %>
+        </div>
+      <% end %>
+
+      <div>
+        <%= form.submit "Post Comment" %>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   resources :users
   resources :tickets do
-    post :assign, on: :member
+    member do
+      post :assign
+      patch :close
+    end
+    resources :comments, only: :create
   end
   get    "/login",  to: "sessions#new"
   delete "/logout", to: "sessions#destroy"

--- a/db/migrate/20251020152700_update_ticket_priority_defaults.rb
+++ b/db/migrate/20251020152700_update_ticket_priority_defaults.rb
@@ -1,0 +1,20 @@
+class UpdateTicketPriorityDefaults < ActiveRecord::Migration[8.0]
+  def up
+    change_column_default :tickets, :priority, from: nil, to: 1
+
+    say_with_time("Setting default priority to medium on existing tickets") do
+      Ticket.reset_column_information
+      Ticket.where(priority: nil).update_all(priority: 1)
+    end
+  end
+
+  def down
+    change_column_default :tickets, :priority, from: 1, to: nil
+  end
+
+  private
+
+  class Ticket < ApplicationRecord
+    self.table_name = "tickets"
+  end
+end

--- a/db/migrate/20251020152800_create_comments.rb
+++ b/db/migrate/20251020152800_create_comments.rb
@@ -1,0 +1,12 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.references :ticket, null: false, foreign_key: true
+      t.references :author, null: false, foreign_key: { to_table: :users }
+      t.text :body, null: false
+      t.integer :visibility, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251020152900_backfill_ticket_categories.rb
+++ b/db/migrate/20251020152900_backfill_ticket_categories.rb
@@ -2,7 +2,7 @@ class BackfillTicketCategories < ActiveRecord::Migration[8.0]
   def up
     say_with_time("Backfilling ticket categories") do
       Ticket.reset_column_information
-      Ticket.where(category: [nil, "General", ""]).update_all(category: "Technical Issue")
+      Ticket.where(category: [ nil, "General", "" ]).update_all(category: "Technical Issue")
     end
   end
 

--- a/db/migrate/20251020152900_backfill_ticket_categories.rb
+++ b/db/migrate/20251020152900_backfill_ticket_categories.rb
@@ -1,0 +1,18 @@
+class BackfillTicketCategories < ActiveRecord::Migration[8.0]
+  def up
+    say_with_time("Backfilling ticket categories") do
+      Ticket.reset_column_information
+      Ticket.where(category: [nil, "General", ""]).update_all(category: "Technical Issue")
+    end
+  end
+
+  def down
+    # no-op
+  end
+
+  private
+
+  class Ticket < ApplicationRecord
+    self.table_name = "tickets"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_20_152600) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_20_152900) do
+  create_table "comments", force: :cascade do |t|
+    t.integer "ticket_id", null: false
+    t.integer "author_id", null: false
+    t.text "body", null: false
+    t.integer "visibility", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_comments_on_author_id"
+    t.index ["ticket_id"], name: "index_comments_on_ticket_id"
+  end
+
   create_table "settings", force: :cascade do |t|
     t.string "key"
     t.text "value"
@@ -22,7 +33,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_152600) do
     t.string "subject"
     t.text "description"
     t.integer "status"
-    t.integer "priority"
+    t.integer "priority", default: 1
     t.integer "requester_id", null: false
     t.integer "assignee_id"
     t.string "category"
@@ -50,6 +61,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_152600) do
     t.index ["role"], name: "index_users_on_role"
   end
 
+  add_foreign_key "comments", "tickets"
+  add_foreign_key "comments", "users", column: "author_id"
   add_foreign_key "tickets", "users", column: "assignee_id"
   add_foreign_key "tickets", "users", column: "requester_id"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :comment do
+    association :ticket
+    association :author, factory: :user
+    body { "This is a comment." }
+    visibility { :public }
+  end
+end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -3,10 +3,10 @@ FactoryBot.define do
     subject { "Test Ticket" }
     description { "Test Description" }
     status { :open }
-    priority { :normal }
+    priority { :medium }
     association :requester, factory: :user
     assignee { nil }
-    category { "General" }
+    category { Ticket::CATEGORY_OPTIONS.first }
     closed_at { nil }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe Comment, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:body) }
-    it { should define_enum_for(:visibility).with_values(public: 0, internal: 1) }
+  end
+
+  describe 'enums' do
+    it 'defines visibility enum with prefixed helpers' do
+      expect(Comment.visibilities.symbolize_keys).to eq({ public: 0, internal: 1 })
+      expect(build(:comment)).to respond_to(:visibility_public?)
+      expect(build(:comment)).to respond_to(:visibility_internal!)
+    end
   end
 
   describe 'scopes' do
@@ -17,7 +24,7 @@ RSpec.describe Comment, type: :model do
       older = create(:comment, ticket: ticket, created_at: 2.days.ago)
       newer = create(:comment, ticket: ticket, created_at: 1.day.ago)
 
-      expect(ticket.comments.chronological).to eq([older, newer])
+      expect(ticket.comments.chronological).to eq([ older, newer ])
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  describe 'associations' do
+    it { should belong_to(:ticket) }
+    it { should belong_to(:author).class_name('User') }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:body) }
+    it { should define_enum_for(:visibility).with_values(public: 0, internal: 1) }
+  end
+
+  describe 'scopes' do
+    it 'orders chronologically' do
+      ticket = create(:ticket)
+      older = create(:comment, ticket: ticket, created_at: 2.days.ago)
+      newer = create(:comment, ticket: ticket, created_at: 1.day.ago)
+
+      expect(ticket.comments.chronological).to eq([older, newer])
+    end
+  end
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Ticket, type: :model do
     it { should validate_presence_of(:subject) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:status) }
-    it { should validate_inclusion_of(:priority).in_array(%w[low medium high]) }
+    it { should validate_presence_of(:priority) }
     it { should validate_presence_of(:category) }
     it { should validate_inclusion_of(:category).in_array(Ticket::CATEGORY_OPTIONS) }
     it { should validate_presence_of(:requester) }

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -8,19 +8,28 @@ RSpec.describe Ticket, type: :model do
   describe 'associations' do
     it { should belong_to(:requester).class_name('User') }
     it { should belong_to(:assignee).class_name('User').optional }
+    it { should have_many(:comments).dependent(:destroy) }
   end
 
   describe 'enums' do
     it { should define_enum_for(:status).with_values(open: 0, pending: 1, resolved: 2, closed: 3) }
-    it { should define_enum_for(:priority).with_values(low: 0, normal: 1, high: 2) }
+    it { should define_enum_for(:priority).with_values(low: 0, medium: 1, high: 2) }
   end
 
   describe 'validations' do
     it { should validate_presence_of(:subject) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:status) }
-    it { should validate_presence_of(:priority) }
+    it { should validate_inclusion_of(:priority).in_array(%w[low medium high]) }
+    it { should validate_presence_of(:category) }
+    it { should validate_inclusion_of(:category).in_array(Ticket::CATEGORY_OPTIONS) }
     it { should validate_presence_of(:requester) }
+  end
+
+  describe 'defaults' do
+    it 'defaults priority to medium' do
+      expect(Ticket.new.priority).to eq("medium")
+    end
   end
 
   describe '#set_closed_at' do

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe CommentPolicy do
+  let(:ticket) { create(:ticket) }
+  let(:requester) { ticket.requester }
+  let(:agent) { create(:user, role: :staff) }
+  let(:admin) { create(:user, role: :sysadmin) }
+
+  subject(:policy) { described_class.new(user, comment) }
+
+  context 'as requester' do
+    let(:user) { requester }
+
+    context 'with public visibility' do
+      let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :public) }
+
+      it { expect(policy.create?).to be true }
+    end
+
+    context 'with internal visibility' do
+      let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :internal) }
+
+      it { expect(policy.create?).to be false }
+    end
+
+    context 'when ticket is closed' do
+      let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :public) }
+
+      before { ticket.update!(status: :closed) }
+
+      it { expect(policy.create?).to be false }
+    end
+  end
+
+  context 'as agent' do
+    let(:user) { agent }
+
+    context 'with internal visibility' do
+      let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :internal) }
+
+      it { expect(policy.create?).to be true }
+    end
+
+    context 'when ticket is closed' do
+      let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :public) }
+
+      before { ticket.update!(status: :closed) }
+
+      it { expect(policy.create?).to be false }
+    end
+  end
+
+  context 'as admin' do
+    let(:user) { admin }
+    let(:comment) { build(:comment, ticket: ticket, author: user, visibility: :internal) }
+
+    it { expect(policy.create?).to be true }
+  end
+end

--- a/spec/policies/ticket_policy_spec.rb
+++ b/spec/policies/ticket_policy_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe TicketPolicy do
     it { expect(subject.permit?(:update)).to be true }
     it { expect(subject.permit?(:edit)).to be true }
     it { expect(subject.permit?(:destroy)).to be true }
+    it { expect(subject.permit?(:close)).to be true }
     it { expect(subject.permit?(:assign)).to be false }
 
     context 'when ticket is closed' do
@@ -25,6 +26,7 @@ RSpec.describe TicketPolicy do
       it { expect(subject.permit?(:update)).to be false }
       it { expect(subject.permit?(:edit)).to be false }
       it { expect(subject.permit?(:destroy)).to be false }
+      it { expect(subject.permit?(:close)).to be false }
     end
   end
 
@@ -39,6 +41,7 @@ RSpec.describe TicketPolicy do
     it { expect(subject.permit?(:edit)).to be true }
     it { expect(subject.permit?(:assign)).to be true }
     it { expect(subject.permit?(:destroy)).to be false }
+    it { expect(subject.permit?(:close)).to be false }
   end
 
   context 'when user is admin' do
@@ -51,6 +54,7 @@ RSpec.describe TicketPolicy do
     it { expect(subject.permit?(:update)).to be true }
     it { expect(subject.permit?(:edit)).to be true }
     it { expect(subject.permit?(:assign)).to be true }
-    it { expect(subject.permit?(:destroy)).to be true }
+    it { expect(subject.permit?(:destroy)).to be false }
+    it { expect(subject.permit?(:close)).to be false }
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  let(:ticket) { create(:ticket) }
+  let(:requester) { ticket.requester }
+  let(:agent) { create(:user, role: :staff) }
+
+  describe "POST /tickets/:ticket_id/comments" do
+    it "allows the requester to add a public comment" do
+      sign_in(requester)
+
+      expect do
+        post ticket_comments_path(ticket), params: {
+          comment: {
+            body: "Additional info from the requester."
+          }
+        }
+      end.to change(Comment, :count).by(1)
+
+      comment = Comment.order(:created_at).last
+      expect(comment.visibility).to eq("public")
+      expect(comment.body).to include("Additional info")
+      expect(response).to redirect_to(ticket_path(ticket))
+    end
+
+    it "ignores internal visibility submitted by requester" do
+      sign_in(requester)
+
+      post ticket_comments_path(ticket), params: {
+        comment: {
+          body: "Trying to sneak an internal note.",
+          visibility: :internal
+        }
+      }
+
+      expect(Comment.order(:created_at).last.visibility).to eq("public")
+    end
+
+    it "allows an agent to create an internal comment" do
+      sign_in(agent)
+
+      expect do
+        post ticket_comments_path(ticket), params: {
+          comment: {
+            body: "Internal triage details.",
+            visibility: :internal
+          }
+        }
+      end.to change(Comment, :count).by(1)
+
+      expect(Comment.order(:created_at).last.visibility).to eq("internal")
+    end
+
+    it "prevents commenting on a closed ticket" do
+      ticket.update!(status: :closed)
+      sign_in(requester)
+
+      expect {
+        post ticket_comments_path(ticket), params: { comment: { body: "Closing remark" } }
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+end

--- a/spec/views/tickets/edit.html.erb_spec.rb
+++ b/spec/views/tickets/edit.html.erb_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe "tickets/edit", type: :view do
   let(:requester) { FactoryBot.create(:user, :requester) }
-  let(:ticket) {
-    Ticket.create!(
+  let(:ticket) do
+    create(
+      :ticket,
       subject: "MyString",
       description: "MyText",
       priority: :low,
       requester: requester,
       status: :pending
     )
-  }
+  end
 
   before(:each) do
     assign(:ticket, ticket)

--- a/spec/views/tickets/index.html.erb_spec.rb
+++ b/spec/views/tickets/index.html.erb_spec.rb
@@ -2,16 +2,22 @@ require 'rails_helper'
 
 RSpec.describe "tickets/index", type: :view do
   let(:requester) { FactoryBot.create(:user, :requester) }
+  let(:policy_double) { instance_double(TicketPolicy, destroy?: false) }
+
   before(:each) do
+    policy = policy_double
+    view.singleton_class.send(:define_method, :policy) { |_record| policy }
     assign(:tickets, [
-      Ticket.create!(
+      create(
+        :ticket,
         subject: "Title",
         description: "MyText",
         priority: :low,
         requester: requester,
         status: :pending
       ),
-      Ticket.create!(
+      create(
+        :ticket,
         subject: "Title",
         description: "MyText",
         priority: :low,
@@ -23,8 +29,8 @@ RSpec.describe "tickets/index", type: :view do
 
   it "renders a list of tickets" do
     render
-    cell_selector = 'div>p'
-    assert_select cell_selector, text: Regexp.new("Title".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+    assert_select 'h2>a', text: "Title", count: 2
+    assert_select 'p', text: /Status:/, count: 2
+    assert_select 'p', text: /Category:/, count: 2
   end
 end

--- a/spec/views/tickets/show.html.erb_spec.rb
+++ b/spec/views/tickets/show.html.erb_spec.rb
@@ -2,14 +2,35 @@ require 'rails_helper'
 
 RSpec.describe "tickets/show", type: :view do
   let(:requester) { FactoryBot.create(:user, :requester) }
+  let(:ticket_policy) { instance_double(TicketPolicy, close?: false, destroy?: false) }
+  let(:comment_policy) { instance_double(CommentPolicy, create?: false) }
+
   before(:each) do
-    assign(:ticket, Ticket.create!(
+    ticket = create(
+      :ticket,
       subject: "Title",
       description: "MyText",
       priority: :low,
       requester: requester,
       status: :pending
-    ))
+    )
+
+    assign(:ticket, ticket)
+    assign(:comments, [])
+    assign(:comment, build(:comment, ticket: ticket, author: requester))
+
+    ticket_policy_double = ticket_policy
+    comment_policy_double = comment_policy
+    view.singleton_class.send(:define_method, :policy) do |record|
+      case record
+      when Ticket
+        ticket_policy_double
+      when Comment
+        comment_policy_double
+      else
+        raise "Unexpected record: #{record.inspect}"
+      end
+    end
   end
 
   it "renders attributes in <p>" do


### PR DESCRIPTION
## 🧾 Summary

This PR delivers full **end-to-end implementation** of the user-facing ticket enhancements, covering categorization, prioritization, lifecycle management, and commenting.

- **Ticket Categorization:**  
  Added dropdown-based category selection validated against a shared constant.  
  Includes migration to backfill legacy tickets with default `"Technical Issue"` category.

- **Ticket Closing & Deletion:**  
  Introduced close/delete flows guarded by Pundit.  
  Requesters can retire their own open tickets; `closed_at` timestamps are updated automatically.  
  UI buttons are conditionally rendered based on policy checks.

- **Commenting System:**  
  Implemented full commenting capability via a dedicated `Comment` model and nested controller.  
  Requester comments are always public; staff can add internal notes.  
  Comments render chronologically with author info and visibility labels.

- **UI Enhancements:**  
  Updated ticket forms, index, and show views to surface category, priority, and status fields.  
  Added comment submission forms and conditional action buttons (close/delete).

- **Testing & Factories:**  
  Expanded FactoryBot definitions and comprehensive specs for model, request, policy, and view layers.  
  Covered new behaviors, default enum values, and policy restrictions.  
  Stubs added for Pundit view helpers where applicable.

---

## 🧩 Implementation Notes

### Schema & Data
- Migrations:
  - Set default priority to `medium`.
  - Backfill existing tickets with category `"Technical Issue"`.
  - Added `comments` table with `visibility` enum (int, default: `public`), and `author_id` foreign key to `users`.
- `Ticket` model:
  - Validates presence/inclusion for `category` and `priority`.
  - Sets default priority via `after_initialize`.
  - Maintains `closed_at` lifecycle hook.
  - Declares `has_many :comments`.

---

### Controllers & Policies
- **TicketsController**
  - `index` filters by category.  
  - `show` preloads comments, scopes visibility, and builds a default public comment instance.  
  - Added `close` member action with corresponding route.  
  - Updated `destroy` to limit deletion to requester-owned open tickets, with new flash copy.
- **TicketPolicy**
  - Only requesters can close or delete their own open tickets.
- **CommentsController**
  - Enforces requester comment visibility and staff internal notes.  
  - Redirects with appropriate flash messages.  
  - Nested under `tickets` resource.
- **CommentPolicy**
  - Mirrors requester/staff visibility rules.  
  - Prevents commenting on closed tickets.

---

### Views
- `_form.html.erb`:  
  - Added dropdown selects for `priority` and `category` with prettified labels.
- `index.html.erb`:  
  - Displays `status`, `priority`, and `category` summaries.  
  - Conditionally shows “Delete” button per policy.
- `show.html.erb`:  
  - Displays ticket metadata in a definition list.  
  - Adds conditional “Close” / “Delete” buttons.  
  - Renders chronological comments with author and visibility tags.  
  - Includes comment form; hides visibility picker for requesters.

---

### Specs & Factories
- Added `comment` factory with associations and enum helpers.  
- Extended `Ticket` model specs for default priority and category validations.  
- Added request specs for ticket `create`, `delete`, and `close` flows.  
- Comment request specs verify visibility enforcement and authorization.  
- Policy specs cover close/destroy/comment rules.  
- View specs stub Pundit helpers and assert new markup.  
- All specs pass (`bundle exec rspec`), with pending view specs unaffected.

---

## ✅ Coverage
This PR completes all **five user stories** assigned to **Yafei Li**, implementing:

1. Ticket type (category) selection  
2. Ticket deletion  
3. Priority field  
4. Ticket closing flow  
5. Commenting functionality  

Together, these changes deliver the full requester-side ticket lifecycle and integrate seamlessly with the assignment workflow.

---

**All tests passing:**  
```bash
bundle exec rspec
# => Green (0 failures)