### PR TITLE
Restrict dev login only to test mode

### DIFF
--- a/config/initializers/omniauth_test_mode.rb
+++ b/config/initializers/omniauth_test_mode.rb
@@ -1,7 +1,7 @@
-if Rails.env.development?
+if Rails.env.test? || ENV["OMNIAUTH_TEST_MODE"] == "true"
   OmniAuth.config.test_mode = true
 
-  # Safe default; we’ll overwrite per-user in DevLoginController
+  # Safe default; we’ll overwrite per-user in DevLoginController or specs
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
     provider: "google_oauth2",
     uid:      "dummy.requester.001",


### PR DESCRIPTION
**Quick fix - fixed google login in dev mode.**

/dev_login gateway only available in test mode.

add to .env

OmniAuth.config.test_mode = true
